### PR TITLE
Jpeg support

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,15 +1,17 @@
 pkgbase = ros-melodic-libuvc
 	pkgdesc = ROS - USB Video Class driver library.
 	pkgver = 0.0.6
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/ktossell/libuvc
 	arch = any
 	license = BSD
 	makedepends = cmake
 	makedepends = ros-build-tools
 	makedepends = libusb
+	makedepends = libjpeg-turbo
 	depends = ros-melodic-catkin
 	depends = libusb
+	depends = libjpeg-turbo
 	source = ros-melodic-libuvc-0.0.6-0.tar.gz::https://github.com/ktossell/libuvc-release/archive/release/melodic/libuvc/0.0.6-0.tar.gz
 	sha256sums = 06a553e6d043735a10fff606d5f71a20661fc9b6be392b69a06c35b8aca8d3f6
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,9 +1,13 @@
 pkgbase = ros-melodic-libuvc
 	pkgdesc = ROS - USB Video Class driver library.
 	pkgver = 0.0.6
-	pkgrel = 3
+	pkgrel = 4
 	url = https://github.com/ktossell/libuvc
-	arch = any
+	arch = i686
+	arch = x86_64
+	arch = aarch64
+	arch = armv7h
+	arch = armv6h
 	license = BSD
 	makedepends = cmake
 	makedepends = ros-build-tools

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,18 +7,20 @@ pkgname='ros-melodic-libuvc'
 pkgver='0.0.6'
 _pkgver_patch=0
 arch=('any')
-pkgrel=2
+pkgrel=3
 license=('BSD')
 
 ros_makedepends=()
 makedepends=('cmake'
              'ros-build-tools'
              ${ros_makedepends[@]}
-             libusb)
+             libusb
+             libjpeg-turbo)
 
 ros_depends=(ros-melodic-catkin)
 depends=(${ros_depends[@]}
-         libusb)
+         libusb
+         libjpeg-turbo)
 
 # Git version (e.g. for debugging)
 # _tag=release/melodic/libuvc/${pkgver}-${_pkgver_patch}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,8 +6,8 @@ url='https://github.com/ktossell/libuvc'
 pkgname='ros-melodic-libuvc'
 pkgver='0.0.6'
 _pkgver_patch=0
-arch=('any')
-pkgrel=3
+arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
+pkgrel=4
 license=('BSD')
 
 ros_makedepends=()


### PR DESCRIPTION
Adds jpeg library to dependencies as jpeg support is compiled in only when that is found. However, downstream packages such as [`libuvc_camera'](https://github.com/ros-melodic-arch/ros-melodic-libuvc-camera) depend on jpeg support.

One problem is that the [corresponding AUR package](https://aur.archlinux.org/packages/ros-melodic-libuvc/) belongs to  user kwrazi so we might have to poke that user manually after merging this.